### PR TITLE
Fix the _retry() method signature to accept an error object

### DIFF
--- a/lib/eventsource.dart
+++ b/lib/eventsource.dart
@@ -104,7 +104,7 @@ class EventSource extends Stream<Event> {
   }
 
   /// Retries until a new connection is established. Uses exponential backoff.
-  Future _retry() async {
+  Future _retry(dynamic e) async {
     _readyState = EventSourceReadyState.CONNECTING;
     // try reopening with exponential backoff
     Duration backoff = _retryDelay;


### PR DESCRIPTION
The onError handler passed to the Stream's listen method is expected
to take an error argument.