### PR TITLE
Added the ability to add custom headers to the EventSource http request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ doc/api/
 *.iml
 *.ipr
 *.iws
+/.dart_tool


### PR DESCRIPTION
I ran into a problem where I'd like to connect to an Event Source which was behind an Endpoint that required Authorization.

So I added the optional `headers` attribute to the connect factory. It accepts a `Map` and merges all its entries with the already present headers of this library.

`EventSource eventSource = await EventSource.connect(
   url, 
   client: httpClient, 
   headers: { 
      "Authorization": "Bearer ..." 
   },
);`
