### PR TITLE
Ability to close eventsource

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ EventSource eventSource = await EventSource.connect("http://example.com/events",
     client: new http.BrowserClient());
 ```
 
+If you wish to have it connect only when the first listener attaches (and not otherwise), then pass the
+optional parameter `openOnlyOnFirstListener` (as true). If you wish to close it after the last listener detaches, then
+pass the optional parmeter `closeOnLastListener`.
+
+```dart
+EventSource eventSource = await EventSource.connect("http://example.com/events", 
+  openOnlyOnFirstListener: true, closeOnLastListener: true);
+```
+
+
 ## Server usage
 
 We recommend using [`shelf_eventsource`](https://pub.dartlang.org/packages/shelf_eventsource) for

--- a/lib/io_server.dart
+++ b/lib/io_server.dart
@@ -5,8 +5,8 @@ import "dart:io" as io;
 import "package:sync/waitgroup.dart";
 
 import "publisher.dart";
-import "src/event.dart";
 import "src/encoder.dart";
+import "src/event.dart";
 
 /// Create a handler to serve [io.HttpRequest] objects for the specified
 /// channel.
@@ -18,7 +18,7 @@ Function createIoHandler(EventSourcePublisher publisher,
 
     // set content encoding to gzip if we allow it and the request supports it
     bool useGzip = gzip &&
-        (request.headers.value(io.HttpHeaders.ACCEPT_ENCODING) ?? "")
+        (request.headers.value(io.HttpHeaders.acceptEncodingHeader) ?? "")
             .contains("gzip");
 
     // set headers and status code

--- a/lib/publisher.dart
+++ b/lib/publisher.dart
@@ -1,7 +1,5 @@
 library eventsource.server;
 
-export "src/event.dart";
-
 import "dart:async";
 
 import "package:logging/logging.dart" as log;
@@ -9,6 +7,8 @@ import "package:logging/logging.dart" as log;
 import "src/event.dart";
 import "src/event_cache.dart";
 import "src/proxy_sink.dart";
+
+export "src/event.dart";
 
 /// An EventSource publisher. It can manage different channels of events.
 /// This class forms the backbone of an EventSource server. To actually serve
@@ -99,7 +99,7 @@ class EventSourcePublisher extends Sink<Event> {
       String lastEventId}) {
     _logFine("New subscriber on channel $channel.");
     // create a sink for the subscription
-    var sub = new ProxySink(onAdd: onEvent, onClose: onClose);
+    var sub = new ProxySink<Event>(onAdd: onEvent, onClose: onClose);
     // save the subscription
     _subsByChannel.putIfAbsent(channel, () => []).add(sub);
     // replay past events

--- a/lib/src/encoder.dart
+++ b/lib/src/encoder.dart
@@ -22,7 +22,7 @@ class EventSourceEncoder extends Converter<Event, List<int>> {
     String payload = convertToString(event);
     List<int> bytes = utf8.encode(payload);
     if (compressed) {
-      bytes = GZIP.encode(bytes);
+      bytes = gzip.encode(bytes);
     }
     return bytes;
   }
@@ -46,7 +46,7 @@ class EventSourceEncoder extends Converter<Event, List<int>> {
   Sink<Event> startChunkedConversion(Sink<List<int>> sink) {
     Sink inputSink = sink;
     if (compressed) {
-      inputSink = GZIP.encoder.startChunkedConversion(inputSink);
+      inputSink = gzip.encoder.startChunkedConversion(inputSink);
     }
     inputSink = utf8.encoder.startChunkedConversion(inputSink);
     return new ProxySink(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ author: Steven Roose <stevenroose@gmail.com>
 homepage: https://github.com/stevenroose/dart-eventsource
 
 environment:
-  sdk: ">=2.3.0 <3.0.0"
+  sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
   collection: ">=1.4.1 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ author: Steven Roose <stevenroose@gmail.com>
 homepage: https://github.com/stevenroose/dart-eventsource
 
 environment:
-  sdk: ">=1.0.0 <3.0.0"
+  sdk: ">=2.3.0 <3.0.0"
 
 dependencies:
   collection: ">=1.4.1 <2.0.0"

--- a/test/codec_test.dart
+++ b/test/codec_test.dart
@@ -3,11 +3,10 @@ library codec_test;
 import "dart:async";
 import "dart:convert";
 
-import "package:test/test.dart";
-
 import "package:eventsource/src/decoder.dart";
 import "package:eventsource/src/encoder.dart";
 import "package:eventsource/src/event.dart";
+import "package:test/test.dart";
 
 Map<Event, String> _VECTORS = {
   new Event(id: "1", event: "Add", data: "This is a test"):
@@ -35,7 +34,7 @@ void main() {
         var stream = new Stream.fromIterable([encoded])
             .transform(new Utf8Encoder())
             .transform(new EventSourceDecoder());
-        stream.listen(expectAsync((decodedEvent) {
+        stream.listen(expectAsync1((decodedEvent) {
           expect(decodedEvent.id, equals(event.id));
           expect(decodedEvent.event, equals(event.event));
           expect(decodedEvent.data, equals(event.data));
@@ -46,13 +45,13 @@ void main() {
       Event event = new Event(id: "1", event: "Add", data: "This is a test");
       String encodedWithRetry =
           "id: 1\nevent: Add\ndata: This is a test\nretry: 100\n\n";
-      var changeRetryValue = expectAsync((Duration value) {
+      var changeRetryValue = expectAsync1((Duration value) {
         expect(value.inMilliseconds, equals(100));
       }, count: 1);
       var stream = new Stream.fromIterable([encodedWithRetry])
           .transform(new Utf8Encoder())
           .transform(new EventSourceDecoder(retryIndicator: changeRetryValue));
-      stream.listen(expectAsync((decodedEvent) {
+      stream.listen(expectAsync1((decodedEvent) {
         expect(decodedEvent.id, equals(event.id));
         expect(decodedEvent.event, equals(event.event));
         expect(decodedEvent.data, equals(event.data));


### PR DESCRIPTION
- added in optional support for closing
and delaying opening the event source. This
keeps it backwards compatible with people who
use it in the way they are using it already.
- cleaned up all dart analyzer issues due to
obsolete/deprecated libraries
- updated README
- upped version of Dart to minimum that the
included existing dependencies require (2.3)
- cleared up export