### PR TITLE
Add Eventsource.close() method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ doc/api/
 *.ipr
 *.iws
 /.dart_tool
+
+pubspec.lock


### PR DESCRIPTION
This PR simply adds the ability to close an event source. It does this by canceling any active connections to the server and then closes the internal controller to ensure all listeners receive the done event.

I also made sure that a cancellation while the event source is trying to reconnect leads to the reconnection being stopped.